### PR TITLE
fetch history for correct versioning when deploying

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - uses: actions/setup-python@v5
         with:
           python-version: 3.11


### PR DESCRIPTION
I encountered an issue with this template, as the automatic versioning is very nice, but does not work well with github action checkout. For the automatic versioning to work, we rely on the checked out git, as discussed somewhere before (can't find the issue/discussion anymore, might have been the old git).

As the 'setuptools-scm' relies on git metadata and as described here:
https://github.com/actions/checkout/issues/249
this PR solves the issue and produces correct version numbers on deployment by checking out the complete history (including tag names etc...). The performance drawback will hopefully be negligible.